### PR TITLE
//ui/pynix/README.md: fix example

### DIFF
--- a/ui/pynix/README.md
+++ b/ui/pynix/README.md
@@ -17,6 +17,6 @@ assert input == output
 import pynix
 
 # Returns a dict with the same shape as nix show-derivation uses
-d = pynix.drvparse("/nix/store/s6rn4jz1sin56rf4qj5b5v8jxjm32hlk-hello-2.10.drv")
+d = pynix.drvparse(open("/nix/store/s6rn4jz1sin56rf4qj5b5v8jxjm32hlk-hello-2.10.drv").read())
 assert isinstance(d, dict)
 ```


### PR DESCRIPTION
pynix.drvparse actually accepts the literal contents of a derivation,
not the path to it (and passes it to `ast.parse`) - so the example needs
to read in the file contents instead of just passing the derivation
path.