### PR TITLE
Add Flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,10 @@ on:
     - '**.md'
 
 jobs:
-
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: cachix/install-nix-action@v12
+    - uses: cachix/install-nix-action@v13
     - uses: actions/checkout@v1
     - name: build
       run: nix-shell --run "make build"
@@ -19,7 +18,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: cachix/install-nix-action@v12
+    - uses: cachix/install-nix-action@v13
     - uses: actions/checkout@v1
     - name: test
       run: nix-shell --run "make test"
@@ -27,7 +26,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: cachix/install-nix-action@v12
+    - uses: cachix/install-nix-action@v13
     - uses: actions/checkout@v1
     - name: lint
       run: nix-shell --run "make lint"
@@ -35,7 +34,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-    - uses: cachix/install-nix-action@v12
+    - uses: cachix/install-nix-action@v13
     - uses: actions/checkout@v1
     - name: format
       run: nix-shell --run "make format"

--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -1,0 +1,18 @@
+name: CI
+on:
+  pull_request:
+  push:
+jobs:
+  nix-flake:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.3.4
+    - uses: cachix/install-nix-action@v13
+      with:
+        install_url: https://nixos-nix-install-tests.cachix.org/serve/lb41az54kzk6j12p81br4bczary7m145/install
+        install_options: '--tarball-url-prefix https://nixos-nix-install-tests.cachix.org/serve'
+        extra_nix_config: |
+          experimental-features = nix-command flakes
+
+    - name: Run Nix Flake Check
+      run: nix flake check

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,117 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1606424373,
+        "narHash": "sha256-oq8d4//CJOrVj+EcOaSXvMebvuTkmBJuT5tzlfewUnQ=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "99f1c2157fba4bfe6211a321fd0ee43199025dbf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1619345332,
+        "narHash": "sha256-qHnQkEp1uklKTpx3MvKtY6xzgcqXDsz5nLilbbuL+3A=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "2ebf2558e5bf978c7fb8ea927dfaed8fefab2e28",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gomod2nix-flake": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "utils": "utils"
+      },
+      "locked": {
+        "lastModified": 1617032337,
+        "narHash": "sha256-BTmMxdIJyjOvOpNOaExcyvmJKI9OuhpWyXfOK164Epc=",
+        "owner": "tweag",
+        "repo": "gomod2nix",
+        "rev": "c78d7b9f15a24eba95fbc228509f513c83709d8b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tweag",
+        "repo": "gomod2nix",
+        "type": "github"
+      }
+    },
+    "naersk-flake": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1620316130,
+        "narHash": "sha256-sU0VS5oJS1FsHsZsLELAXc7G2eIelVuucRw+q5B1x9k=",
+        "owner": "nmattia",
+        "repo": "naersk",
+        "rev": "a3f40fe42cc6d267ff7518fa3199e99ff1444ac4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nmattia",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1615709438,
+        "narHash": "sha256-hDLC1wVzcD+9dt1U9QpbP0v9bOYD9NGczsobHIEhDYw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3a7674c896847d18e598fa5da23d7426cb9be3d2",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "rev": "3a7674c896847d18e598fa5da23d7426cb9be3d2",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "gomod2nix-flake": "gomod2nix-flake",
+        "naersk-flake": "naersk-flake",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1601282935,
+        "narHash": "sha256-WQAFV6sGGQxrRs3a+/Yj9xUYvhTpukQJIcMbIi7LCJ4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "588973065fce51f4763287f0fda87a174d78bf48",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,72 @@
+{
+  description = "Trustix: Distributed trust and reproducibility tracking for binary caches";
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "nixpkgs/3a7674c896847d18e598fa5da23d7426cb9be3d2";
+    flake-compat = { url = "github:edolstra/flake-compat"; flake = false; };
+    gomod2nix-flake = { url = "github:tweag/gomod2nix"; inputs.nixpkgs.follows = "nixpkgs"; };
+    naersk-flake = { url = "github:nmattia/naersk"; inputs.nixpkgs.follows = "nixpkgs"; };
+  };
+
+  outputs =
+    inputs@{ self
+    , nixpkgs
+    , flake-utils
+    , flake-compat
+    , gomod2nix-flake
+    , naersk-flake
+    }:
+    { }
+    //
+    (flake-utils.lib.eachSystem [ "x86_64-linux" "x86_64-darwin" ]
+      (system:
+      let
+        pkgs = import nixpkgs
+          {
+            inherit system;
+            overlays = [
+              self.overlay
+              gomod2nix-flake.overlay
+              naersk-flake.overlay
+            ];
+            config = {
+              allowUnsupportedSystem = true; #enable for multi-arch check
+              allowBroken = true;
+            };
+          };
+      in
+      rec {
+        devShell = import ./shell.nix { inherit pkgs; };
+        defaultPackage = pkgs.trustix;
+        packages = {
+          inherit (pkgs)
+            nix-nar-unpack trustix trustix-nix trustix-nix-reprod;
+        };
+        hydraJobs = {
+          inherit packages;
+        };
+      }
+      )
+    ) //
+    {
+      overlay = final: prev:
+        let
+          inherit (prev) lib;
+          dirNames = lib.attrNames (lib.filterAttrs (pkgDir: type: type == "directory" && builtins.pathExists (./packages + "/${pkgDir}/default.nix")) (builtins.readDir ./packages));
+        in
+        (
+          builtins.listToAttrs (map
+            (pkgDir: {
+              value = prev.callPackage (./packages + "/${pkgDir}") { };
+              name = pkgDir;
+            })
+            dirNames)
+        ) // {
+          hydra-eval-jobs = prev.runCommand "hydra-eval-jobs-${prev.hydra-unstable.version}" { } ''
+            mkdir -p $out/bin
+            cp -s ${prev.hydra-unstable}/bin/hydra-eval-jobs $out/bin/
+          '';
+        };
+    };
+}

--- a/packages/trustix-nix/shell.nix
+++ b/packages/trustix-nix/shell.nix
@@ -1,7 +1,7 @@
 { pkgs ? import ../../nix }:
 
 let
-  rootShell = import ../../shell.nix;
+  rootShell = import ../../shell.nix { };
 
 in
 pkgs.mkShell {

--- a/packages/trustix/shell.nix
+++ b/packages/trustix/shell.nix
@@ -1,16 +1,16 @@
 { pkgs ? import ../../nix }:
 
 let
-  rootShell = import ../../shell.nix;
+  rootShell = import ../../shell.nix { };
 
 in
-pkgs.mkShell {
-
+pkgs.mkShell rec {
+  inherit (rootShell) TRUSTIX_RPC STATE_DIR;
   # Speed up compilation
   CGO_ENABLED = "0";
 
-  TRUSTIX_STATE_DIR = rootShell.STATE_DIR + "/trustix";
-  inherit (rootShell) TRUSTIX_RPC;
+  TRUSTIX_STATE_DIR = STATE_DIR + "trustix";
+
 
   buildInputs = [
     pkgs.hivemind # Process monitoring in development

--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,5 @@
+{ pkgs ? import ./nix }:
 let
-  pkgs = import ./nix;
-
   STATE_DIR = "${builtins.toString ./.}/state";
   TRUSTIX_RPC = "unix://${STATE_DIR}/trustix.sock";
   TRUSTIX_ROOT = builtins.toString ./.;


### PR DESCRIPTION
Please, check it out, make sure each of the packages should be in the output of packages.
- Check the nix flake show.

```
├───defaultPackage
│   ├───x86_64-darwin: package 'trustix-dev'
│   └───x86_64-linux: package 'trustix-dev'
├───devShell
│   ├───x86_64-darwin: development environment 'nix-shell'
│   └───x86_64-linux: development environment 'nix-shell'
├───hydraJobs
│   ├───x86_64-darwin
│   │   └───packages
│   │       ├───nix-nar-unpack: derivation 'nix-nar-unpack-0.1.0'
│   │       ├───trustix: derivation 'trustix-dev'
│   │       ├───trustix-nix: derivation 'trustix-dev'
│   │       └───trustix-nix-reprod: derivation 'python3.8-trustix-nix-reprod-0.1.0'
│   └───x86_64-linux
│       └───packages
│           ├───nix-nar-unpack: derivation 'nix-nar-unpack-0.1.0'
│           ├───trustix: derivation 'trustix-dev'
│           ├───trustix-nix: derivation 'trustix-dev'
│           └───trustix-nix-reprod: derivation 'python3.8-trustix-nix-reprod-0.1.0'
├───overlay: Nixpkgs overlay
└───packages
    ├───x86_64-darwin
    │   ├───nix-nar-unpack: package 'nix-nar-unpack-0.1.0'
    │   ├───trustix: package 'trustix-dev'
    │   ├───trustix-nix: package 'trustix-dev'
    │   └───trustix-nix-reprod: package 'python3.8-trustix-nix-reprod-0.1.0'
    └───x86_64-linux
        ├───nix-nar-unpack: package 'nix-nar-unpack-0.1.0'
        ├───trustix: package 'trustix-dev'
        ├───trustix-nix: package 'trustix-dev'
        └───trustix-nix-reprod: package 'python3.8-trustix-nix-reprod-0.1.0'

```
-  Fix: nix-shell error output

```
error: value is a function while a set was expected
            6| in
            7| pkgs.mkShell {
             |               ^
            8|   # Speed up compilation
(use '--show-traces to show detailed location information)
```

- Add nix flake CI check:
Only enabled `nix flake CI`, If we need other options of testing in flake. 


Any idea about this PR?