### PR TITLE
types.AttrsOf -> types.attrsOf

### DIFF
--- a/packages/trustix/nixos/default.nix
+++ b/packages/trustix/nixos/default.nix
@@ -99,7 +99,7 @@ let
         };
 
         meta = mkOption {
-          type = types.AttrsOf types.str;
+          type = types.attrsOf types.str;
           default = { };
           description = ''
             Arbitrary metadata to set for a log.
@@ -152,7 +152,7 @@ let
         };
 
         meta = mkOption {
-          type = types.AttrsOf types.str;
+          type = types.attrsOf types.str;
           default = { };
           description = ''
             Arbitrary metadata to set for a log.


### PR DESCRIPTION
not sure if this PR is right but I got:

```
warning: Git tree '/home/bbigras/nix-config' is dirty
error: attribute 'AttrsOf' missing

       at /nix/store/nwqmz3fbky1klvwmzz3azj5xmihpy9y8-source/packages/trustix/nixos/default.nix:102:18:

          101|         meta = mkOption {
          102|           type = types.AttrsOf types.str;
             |                  ^
          103|           default = { };
(use '--show-trace' to show detailed location information)
```