### PR TITLE
fix decider submodules to allow them to be null

### DIFF
--- a/packages/trustix/nixos/default.nix
+++ b/packages/trustix/nixos/default.nix
@@ -5,8 +5,10 @@ let
 
   configFile =
     let
+      # toml doesn't have a "NoneType" so we must remove null attributes
+      filterNull = attrs: lib.filterAttrsRecursive (n: v: v != null) attrs;
       configJSON = pkgs.writeText "trustix-config.json" (builtins.toJSON (
-        builtins.removeAttrs cfg [ "enable" "package" ]
+        filterNull (builtins.removeAttrs cfg [ "enable" "package" ])
       ));
     in
     pkgs.runCommand "trustix-config.toml"
@@ -22,10 +24,11 @@ let
   deciderOpts =
     let
       mkDeciderModule = name: { ... }@options: mkOption {
-        type = types.submodule {
+        type = types.nullOr (types.submodule {
           inherit options;
-        };
+        });
         description = "Configuration for the ${name} decision engine.";
+        default = null;
       };
     in
     {

--- a/packages/trustix/nixos/default.nix
+++ b/packages/trustix/nixos/default.nix
@@ -30,17 +30,10 @@ let
         description = "Configuration for the ${name} decision engine.";
         default = null;
       };
-    in
-    {
-      options = {
+      mkDeciderModules = attrs: lib.mapAttrs (name: options: mkDeciderModule name options) attrs;
 
-        engine = mkOption {
-          type = types.enum [ "percentage" "lua" "logid" ];
-          example = "percentage";
-          description = "Which decision engine to use.";
-        };
-
-        percentage = mkDeciderModule "percentage" {
+      deciderModules = {
+        percentage = {
           minimum = mkOption {
             type = types.nullOr types.int;
             description = "Minimum agreement percentage.";
@@ -48,7 +41,7 @@ let
           };
         };
 
-        javascript = mkDeciderModule "javascript" {
+        javascript = {
           minimum = mkOption {
             type = types.nullOr types.lines;
             description = "JS script.";
@@ -56,15 +49,26 @@ let
           };
         };
 
-        logid = mkDeciderModule "logid" {
+        logid = {
           minimum = mkOption {
             type = types.nullOr types.str;
             description = "Configured log name to match.";
             default = null;
           };
         };
-
       };
+
+    in
+    {
+      options = {
+
+        engine = mkOption {
+          type = types.enum (lib.mapAttrsToList (name: _: name) deciderModules);
+          example = "percentage";
+          description = "Which decision engine to use.";
+        };
+
+      } // mkDeciderModules deciderModules;
     };
 
   pubKeyOpts =


### PR DESCRIPTION
- fix decider submodules to allow them to be null
  - Resolves #16
- set decider engine enum programmatically to avoid mistakes
  - Resolves #13

I'm happy to move `deciderModules` inline with `} // mkDeciderModules deciderModules;` if you'd prefer