### PR TITLE
Move post-build-hook script to its own derivation

### DIFF
--- a/packages/trustix-nix/nixos/post-build-hook.nix
+++ b/packages/trustix-nix/nixos/post-build-hook.nix
@@ -3,8 +3,12 @@
 let
   cfg = config.services.trustix-nix-build-hook;
 
-  inherit (lib) mkOption types;
+  hook-script = pkgs.writeScript "trustix-hook"
+    ''
+      ${lib.getBin pkgs.trustix-nix}/bin/trustix-nix post-build-hook --address ${cfg.trustix-rpc}
+    '';
 
+  inherit (lib) mkOption types;
 in
 {
 
@@ -29,7 +33,7 @@ in
 
   config = lib.mkIf cfg.enable {
     nix.extraOptions = ''
-      post-build-hook = ${lib.getBin pkgs.trustix-nix}/bin/trustix-nix post-build-hook --address ${cfg.trustix-rpc}
+      post-build-hook = ${hook-script}
     '';
   };
 


### PR DESCRIPTION
It seems the post-build-hook configuration option, at least on my nix
version (2.3.12), accepts only the path to an executable, not a complete
command line. Without this change I got:

```
post-build-hook: error: executing '/nix/store/g48w1vfxbl1p7rbsmd1y999g45c61r7z-trustix-dev/bin/trustix-nix post-build-hook --address /run/trustix-daemon.socket': No such file or directory
```

Also had to prefix the address path with `unix://` to make the dialer
accept it.