### PR TITLE
Update description to match trustix default.nix

### DIFF
--- a/packages/trustix-nix/nixos/binarycache.nix
+++ b/packages/trustix-nix/nixos/binarycache.nix
@@ -40,7 +40,7 @@ in
   config = lib.mkIf cfg.enable {
 
     systemd.sockets.trustix = {
-      description = "Socket for the Trustix Nix binary cache daemon";
+      description = "Socket for the Trustix daemon";
       wantedBy = [ "sockets.target" ];
       listenStreams = [ (toString cfg.port) ];
     };


### PR DESCRIPTION
There are two values declared for the `systemd.sockets.trustix.description` attr, one here and one [here](https://github.com/tweag/trustix/blob/fe726118f9f6ecd9739554ac16f32b499ad7a981/packages/trustix/nixos/default.nix#L241). We want them to match or Nix throws an error.