### PR TITLE
doc: update publicKey

### DIFF
--- a/packages/trustix-doc/src/publishing.md
+++ b/packages/trustix-doc/src/publishing.md
@@ -53,7 +53,7 @@ In this tutorial we are using `/var/trustix/keys` but you are free to use whatev
         publicKey = {
           type = "ed25519";
           # Contents of the generated trustix-pub
-          pub = "2uy8gNIOYEewTiV7iB7cUxBGpXxQtdlFepFoRvJTCJo=";
+          key = "2uy8gNIOYEewTiV7iB7cUxBGpXxQtdlFepFoRvJTCJo=";
         };
       }
     ];

--- a/packages/trustix-doc/src/subscribing.md
+++ b/packages/trustix-doc/src/subscribing.md
@@ -20,7 +20,7 @@ This document walks you through how to subscribe to an already published binary 
         publicKey = {
           type = "ed25519";
           # Contents of the generated trustix-pub
-          pub = "2uy8gNIOYEewTiV7iB7cUxBGpXxQtdlFepFoRvJTCJo=";
+          key = "2uy8gNIOYEewTiV7iB7cUxBGpXxQtdlFepFoRvJTCJo=";
         };
       }
     ];


### PR DESCRIPTION
was changed in code (https://github.com/tweag/trustix/commit/fe726118f9f6ecd9739554ac16f32b499ad7a981), but not documentation

lead to error:

> error: The option `services.trustix.publishers.[definition 1-entry 1].publicKey.pub' does not exist.