### PR TITLE
Extend and fix trustix-nix-cache module

### DIFF
--- a/packages/trustix-nix/nixos/binarycache.nix
+++ b/packages/trustix-nix/nixos/binarycache.nix
@@ -52,7 +52,7 @@ in
 
       serviceConfig = {
         Type = "simple";
-        ExecStart = "${lib.getBin cfg.package}/bin/trustix-nix binary-cache-proxy --privkey ${cfg.private-key}";
+        ExecStart = "${lib.getBin cfg.package}/bin/trustix-nix binary-cache-proxy --address unix://${cfg.trustix-rpc} --privkey ${cfg.private-key}";
         DynamicUser = true;
       };
     };


### PR DESCRIPTION
Fixes https://github.com/tweag/trustix/issues/37

Fixes follow up problem:

not listening on port

Set default port.

Add openFirewall option similar to other nixos modules.

Removed `systemd.sockets.trustix`. No idea what that is supposed to do. It does not make much sense that the port 9001 is bound to the trustix daemon socket. Instead, the trustix-nix-cache should listen on it!

With this changes, the service start:

```
May 08 05:00:15 gaming systemd[1]: Started Trustix Nix binary cache daemon.
May 08 05:00:15 gaming trustix-nix[498069]: time="2022-05-08T05:00:15+02:00" level=debug msg="Dialing remote" address="unix:///run/trustix-daemon.socket"
May 08 05:00:15 gaming trustix-nix[498069]: time="2022-05-08T05:00:15+02:00" level=info msg="Listening to address" address="127.0.0.1:9001"
```

http://127.0.0.1:9001/nix-cache-info

```
StoreDir: /nix/store
WantMassQuery: 1
Priority: 40
```

Tested all settings.